### PR TITLE
Introduced controlhost_dependency_maven, controlhost_dependency_java,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ This role requires Ansible 2.0 or higher.
 
 Available variables are listed below, along with default values.
 
+    controlhost_dependency_maven: true
+
+Enables / disables the maven role dependency.
+
+    controlhost_dependency_java: true
+
+Enables / disables the java role dependency.
+
+    controlhost_dependency_epel: true
+
+Enables / disables the epel role dependency.
+
+    controlhost_dependency_terraform: true
+
+Enables / disables the terraform role dependency.
+
     controlhost_user: "{{ ansible_env.SUDO_USER | default(ansible_env.USER) }}"
 
 The user on the controlhost.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,15 @@
+# Enables / disables the maven role dependency
+controlhost_dependency_maven: true
+
+# Enables / disables the java role dependency
+controlhost_dependency_java: true
+
+# Enables / disables the epel role dependency
+controlhost_dependency_epel: true
+
+# Enables / disables the terraform role dependency
+controlhost_dependency_terraform: true
+
 # The user on the controlhost
 controlhost_user: "{{ ansible_env.SUDO_USER | default(ansible_env.USER) }}"
 # The users group on the controlhost

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,7 +28,10 @@ dependencies:
         "dependency",
         "dependency.epel"
       ],
-      when: ansible_os_family == 'RedHat'
+      when: [
+          ansible_os_family == 'RedHat',
+          controlhost_dependency_epel
+        ]
   }
   - {
       role: srsp.oracle-java,
@@ -36,7 +39,8 @@ dependencies:
       tags: [
         "dependency",
         "dependency.java"
-      ]
+      ],
+      when: controlhost_dependency_java
   }
   - {
       role: gantsign.maven,
@@ -44,12 +48,14 @@ dependencies:
       tags: [
         "dependency",
         "dependency.maven"
-      ]
+      ],
+      when: controlhost_dependency_maven
   }
   - { role: andrewrothstein.terraform,
       version: v2.2.10,
       tags: [
         "dependency",
         "dependency.terraform"
-      ]
+      ],
+      when: controlhost_dependency_terraform
   }

--- a/tasks/env/setup.yml
+++ b/tasks/env/setup.yml
@@ -1,7 +1,7 @@
 - name: "env : setup : Configure default editor"
   blockinfile:
     path: "{{ controlhost_bashrc }}"
-    block: "export EDITOR={{ controlhost_bashrc_editor }}"
+    block: "export EDITOR={{ controlhost_default_editor }}"
     marker: "# {mark} editor ANSIBLE MANAGED BLOCK"
   when: controlhost_default_editor is defined
 

--- a/tasks/maven/encrypt_password.yml
+++ b/tasks/maven/encrypt_password.yml
@@ -1,9 +1,10 @@
 - name: "Maven : encrypt_password : Encrpyt maven server password when maven master password is defined."
   block:
   - name: "Maven : encrypt_password : encrypt maven server password"
-    shell: "mvn --encrypt-password {{ item.password }}"
+    command: "mvn --encrypt-password {{ item.password }}"
     register: _maven_encrypted_server_password
     become_user: "{{ controlhost_user }}"
+    become: yes
     no_log: true
 
   - name: "Maven : encrypt_password : set password fact for server with id : {{ item.id}}"

--- a/tasks/maven/setup.yml
+++ b/tasks/maven/setup.yml
@@ -14,7 +14,7 @@
 - name: "Maven : setup: Configure settings-security.xml"
   block:
   - name: "Maven : setup : create maven master password"
-    shell: "mvn --encrypt-master-password {{ controlhost_maven_master_password }}"
+    command: "mvn --encrypt-master-password {{ controlhost_maven_master_password }}"
     no_log: true
     register: _maven_master_password_result
 

--- a/tasks/maven/setup.yml
+++ b/tasks/maven/setup.yml
@@ -31,7 +31,6 @@
       group: "{{ controlhost_group }}"
       mode: 0640
 
-  become_user: "{{ controlhost_user }}"
   when:
     - _maven_settings_security_stats.stat.exists == false
     - controlhost_maven_master_password is defined

--- a/tasks/packages/pip.yml
+++ b/tasks/packages/pip.yml
@@ -3,6 +3,8 @@
     name: "pip"
     state: latest
   when: controlhost_packages_pip_upgrade
+  tags:
+    - skip_ansible_lint
 
 - name: "packages : pip : Install required PIP packages."
   pip:


### PR DESCRIPTION
Introduced 
* controlhost_dependency_maven
* controlhost_dependency_java
* controlhost_dependency_epel and 
* controlhost_dependency_terraform 

in order to activate/deactivate dependencies.

* Fixed default editor in environment setup
* Removed `become_user` during configuring settings-security.xml