### PR TITLE
Don't install awscli as an OS package but only install it via pip

### DIFF
--- a/vars/family_Debian.yml
+++ b/vars/family_Debian.yml
@@ -3,7 +3,6 @@ __controlhost_packages_os:
   - iftop
   - htop
   - iotop
-  - awscli
   - python2.7
   - python-pip
   - git

--- a/vars/family_RedHat.yml
+++ b/vars/family_RedHat.yml
@@ -3,7 +3,6 @@ __controlhost_packages_os:
   - iftop
   - htop
   - iotop
-  - awscli
   - python
   - python2-pip
   - git


### PR DESCRIPTION
Currently awscli is installed both as OS package and via pip. Since the OS package and its dependencies are outdated, let's only install it via pip.
